### PR TITLE
Add Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,45 @@
+declare module 'reduxsauce' {
+  import { AnyAction, Reducer } from 'redux';
+
+  export interface Actions {
+    [action: string]: string[] | null;
+  }
+
+  export interface ActionTypes {
+    [action: string]: string;
+  }
+
+  export interface ActionCreators {
+    [action: string]: (...args: any[]) => AnyAction;
+  }
+
+  export interface Handlers<S> {
+    [type: string]: (state: S, action: AnyAction) => S;
+  }
+
+  /**
+   * Custom options for created types and actions
+   *
+   * prefix - prepend the string to all created types
+   */
+  interface Options {
+    prefix: string;
+  }
+
+  interface CreatedActions {
+    Types: ActionTypes;
+    Creators: ActionCreators;
+  }
+
+  export function createActions(
+    actions: Actions,
+    options?: Options
+  ): CreatedActions;
+
+  export function createReducer<S>(
+    initialState: S,
+    handlers: Handlers<S>
+  ): Reducer<S>;
+
+  export function createTypes(types: string, options?: Options): ActionTypes;
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "files": [
     "dist/reduxsauce.js",
     "lib",
-    "README.md"
+    "README.md",
+    "index.d.ts"
   ],
   "dependencies": {
     "ramda": "^0.24.1",
@@ -45,6 +46,9 @@
     "rollup-plugin-filesize": "^1.4.2",
     "rollup-plugin-ramda": "^1.0.5",
     "standard": "^10.0.1"
+  },
+  "peerDependencies": {
+    "redux": "4.x"
   },
   "ava": {
     "require": [


### PR DESCRIPTION
Reference: #46 

I did not add typings for resettableReducer. Also @skellock I noticed that redux was removed as a dependency as part of 1.0.0. Since redux ships with useful types it's nice to be able to import those. I've added redux as a peer dependency here but it would make more sense for it to exist as a dev dependency. 