### PR TITLE
Allow null initial state in createReducer

### DIFF
--- a/lib/createReducer.js
+++ b/lib/createReducer.js
@@ -8,7 +8,7 @@ import { DEFAULT } from './Types'
  */
 export default (initialState, handlers) => {
   // initial state is required
-  if (isNil(initialState)) {
+  if (initialState === undefined) {
     throw new Error('initial state is required')
   }
 

--- a/test/createReducerTest.js
+++ b/test/createReducerTest.js
@@ -3,8 +3,8 @@ import createReducer from '../lib/createReducer'
 import * as Types from '../lib/Types'
 
 test('throws an error when initial state is missing', (t) => {
-  t.throws(() => createReducer(null))
   t.throws(() => createReducer())
+  t.throws(() => createReducer(undefined))
 })
 
 test('throws an error when the handlers are not an object', (t) => {
@@ -69,4 +69,14 @@ test('invokes the correct action on an object', (t) => {
   const r = createReducer(i, { 'hi': a })
   const v = r(i, { type: 'hi' })
   t.deepEqual(v, { i: 6 })
+})
+
+test('allows a reducer with null initial state', (t) => {
+  const i = null
+  const a = (state, action) => 'hello';
+  const r = createReducer(i, { 'hi': a })
+  const v = r(i, {type: 'unknown action'})
+  t.is(v, null)
+  const v2 = r(i, {type: 'hi'})
+  t.is(v2, 'hello')
 })


### PR DESCRIPTION
Addresses issue #49 

It would be nice to allow `null` as `initialState` argument to `createReducer`.

Rationale:
- It's useful when aggresively decomposing reducers (e.g. could have a reducer that controls a nullable string state)
- redux `composeReducers` also allows nullable state values, but disallows `undefined` https://github.com/reduxjs/redux/blob/9b43c56b98cc75505e161b8e26c18240fa99b184/src/combineReducers.js#L70-L78