### PR TITLE
Generalized .d.ts typedef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,20 @@
 declare module 'reduxsauce' {
-  import { AnyAction, Reducer } from 'redux';
+  import { Action, AnyAction, Reducer } from 'redux';
 
   export interface Actions {
     [action: string]: string[] | null;
   }
 
-  export interface ActionTypes {
+  export interface DefaultActionTypes {
     [action: string]: string;
   }
 
-  export interface ActionCreators {
+  export interface DefaultActionCreators {
     [action: string]: (...args: any[]) => AnyAction;
   }
 
-  export interface Handlers<S> {
-    [type: string]: (state: S, action: AnyAction) => S;
+  export interface Handlers<S, A = AnyAction> {
+    [type: string]: (state: S, action: A) => S;
   }
 
   /**
@@ -26,20 +26,20 @@ declare module 'reduxsauce' {
     prefix: string;
   }
 
-  interface CreatedActions {
-    Types: ActionTypes;
-    Creators: ActionCreators;
+  export interface CreatedActions<T = DefaultActionTypes, C = DefaultActionCreators> {
+    Types: T;
+    Creators: C;
   }
 
-  export function createActions(
+  export function createActions<T = DefaultActionTypes, C = DefaultActionCreators>(
     actions: Actions,
     options?: Options
-  ): CreatedActions;
+  ): CreatedActions<T, C>;
 
-  export function createReducer<S>(
+  export function createReducer<S = {}, A extends Action = AnyAction>(
     initialState: S,
-    handlers: Handlers<S>
-  ): Reducer<S>;
+    handlers: Handlers<S, A>
+  ): Reducer<S, A>;
 
-  export function createTypes(types: string, options?: Options): ActionTypes;
+  export function createTypes<T = DefaultActionTypes>(types: string, options?: Options): T;
 }


### PR DESCRIPTION
Hello there :)

I've been using this lib for some time now and I really enjoy it, didn't know it had typescript definitions tho since I've been using it at work and our codebase is js only, no ts... Anyway, when I saw the current typedef I thought it didn't let the developer be as thorough with their definitions as they may want to be so I made a few additions... I think someone proposed something similar to this PR in a question as well...

An example of how to use the new typedef:

```typescript
import { AnyAction } from 'redux';
import { createActions, createReducer } from 'reduxsauce';

export interface MyActionTypes {
  DO_IT: string;
}

export interface MyActionCreators {
  doIt: (data: { anakin: string }) => AnyAction;
}

const { Types, Creators } = createActions<MyActionTypes, MyActionCreators>({
  doIt: [ 'data' ]
}, { prefix: 'PALPATINE_' });

const reducer = createReducer({ anakin: 'its not the jedi way', dooku: { more: 'powerful', than: 'any jedi' } }, {
  [Types.DO_IT]: (state, { data }) => ({ ...state, ...data })
});
```

The main idea was to keep the old definition as default while allowing the developer to provide more granular definitions for their specific use case. I tested this a bit and was quite pleased, I hope you will be too. I did try to eliminate the need to declare the action types as a separate interface but it does not seem to be possible to just grab some keys from a definition, map them to screaming snake case and then use them in another definition...

Hope to hear some feedback soon!